### PR TITLE
feat: Add manual revalidation admin page

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function handleRevalidate(path: string) {
+  if (!path) {
+    return { message: "Error: Path is required.", success: false };
+  }
+
+  try {
+    revalidatePath(path);
+    return {
+      message: `Successfully revalidated path: ${path}`,
+      success: true,
+    };
+  } catch (error) {
+    let errorMessage = "Error revalidating";
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    return { message: errorMessage, success: false };
+  }
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,78 @@
+// app/admin/page.tsx
+"use client";
+
+import { useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { handleRevalidate } from "./actions";
+
+function RevalidationForm() {
+  const [path, setPath] = useState("");
+  const [message, setMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setMessage("Revalidating...");
+
+    const result = await handleRevalidate(path);
+
+    setMessage(result.message);
+    setIsSubmitting(false);
+    if (result.success) {
+      setPath("");
+    }
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Manual Revalidation</h1>
+      <p>Enter the path you want to revalidate (e.g., `/latest-news/`).</p>
+      <form onSubmit={handleSubmit} style={{ display: "flex", gap: "1rem" }}>
+        <input
+          type="text"
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          placeholder="/path-to-revalidate"
+          style={{ padding: "0.5rem", minWidth: "300px" }}
+          required
+          disabled={isSubmitting}
+        />
+        <button
+          type="submit"
+          style={{ padding: "0.5rem 1rem" }}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Revalidating..." : "Revalidate"}
+        </button>
+      </form>
+      {message && <p style={{ marginTop: "1rem" }}>{message}</p>}
+    </div>
+  );
+}
+
+function AdminPageContent() {
+  const searchParams = useSearchParams();
+  const secret = searchParams.get("secret");
+
+  const adminKey = process.env.NEXT_PUBLIC_REVALIDATION_ADMIN_KEY;
+
+  if (secret !== adminKey) {
+    return (
+      <div style={{ padding: "2rem" }}>
+        <h1>Access Denied</h1>
+        <p>You do not have permission to view this page.</p>
+      </div>
+    );
+  }
+
+  return <RevalidationForm />;
+}
+
+export default function AdminPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AdminPageContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
This commit adds a new admin page at `/admin` that allows you to manually trigger revalidation for a specific path.

This provides a reliable way to see content updates from the WordPress backend on the Next.js site instantly, without needing to set up or debug WordPress webhook plugins.

The changes include:
- A new page component at `app/admin/page.tsx` which provides the form UI.
- A new server action in `app/admin/actions.ts` that handles the revalidation logic by calling `revalidatePath`.
- The admin page is secured with a secret key passed as a URL query parameter. The key is read from the `NEXT_PUBLIC_REVALIDATION_ADMIN_KEY` environment variable.